### PR TITLE
Fix new package versions not appearing in search

### DIFF
--- a/lib/elm/platform/parser.ex
+++ b/lib/elm/platform/parser.ex
@@ -66,7 +66,7 @@ defmodule Elm.Platform.Parser do
       Decode.succeed(Function.curry(&%Searchable{name: &1, summary: &2, versions: &3}))
       |> Decode.and_map(Decode.field("name", name))
       |> Decode.and_map(Decode.field("summary", Decode.string()))
-      |> Decode.and_map(Decode.field("versions", Decode.list(version)))
+      |> Decode.and_map(Decode.map(Decode.field("version", version), fn val -> [val] end))
 
     Decode.list(searchable)
   end


### PR DESCRIPTION
Long time no pull requests, what's up man!?

This should fix https://github.com/ellie-app/ellie/issues/125

The package site updated the endpoint https://package.elm-lang.org/search.json so that it only includes the latest version, rather than an array of versions in the response.

I tested this out locally and was able to run a project with mdgriffith/elm-animator locally (it doesn't appear on the Ellie search results at the moment)